### PR TITLE
Make separated analysis results for enwiki and jawiki

### DIFF
--- a/src/main/perf/TestAnalyzerPerf.java
+++ b/src/main/perf/TestAnalyzerPerf.java
@@ -166,12 +166,20 @@ public class TestAnalyzerPerf {
 
   public static void main(String[] args) throws Exception {
     File wikiLinesFile = new File(args[0]);
-    File jaWikiLinesFile = new File(args[1]);
-    testAnalyzer("Standard", wikiLinesFile, new StandardAnalyzer(CharArraySet.EMPTY_SET));
-    testAnalyzer("LowerCase", wikiLinesFile, new LowerCaseAnalyzer());
-    testAnalyzer("EdgeNGrams", wikiLinesFile, new EdgeNGramsAnalyzer());
-    testAnalyzer("Shingles", wikiLinesFile, new ShinglesAnalyzer());
-    testAnalyzer("WordDelimiterFilter", wikiLinesFile, new WDFAnalyzer());
-    testAnalyzer("Japanese", jaWikiLinesFile, new JapaneseAnalyzer());
+    String lang = "en";
+    if (args.length > 1) {
+      lang = args[1];
+    }
+    if (lang.equals("en")) {
+      testAnalyzer("Standard", wikiLinesFile, new StandardAnalyzer(CharArraySet.EMPTY_SET));
+      testAnalyzer("LowerCase", wikiLinesFile, new LowerCaseAnalyzer());
+      testAnalyzer("EdgeNGrams", wikiLinesFile, new EdgeNGramsAnalyzer());
+      testAnalyzer("Shingles", wikiLinesFile, new ShinglesAnalyzer());
+      testAnalyzer("WordDelimiterFilter", wikiLinesFile, new WDFAnalyzer());
+    } else if (lang.equals("ja")) {
+      testAnalyzer("Japanese", wikiLinesFile, new JapaneseAnalyzer());
+    } else {
+      throw new IllegalArgumentException("Unknown lang: " + lang);
+    }
   }
 }

--- a/src/python/wikiXMLToText.py
+++ b/src/python/wikiXMLToText.py
@@ -90,7 +90,6 @@ def convert(fIn, fOut):
   # get the root element
   event, root = context.next()
 
-  attrs = {}
   isRedirect = False
   count = 0
 
@@ -106,6 +105,8 @@ def convert(fIn, fOut):
     'subSectionCount',
     'subSubSectionCount',
     'refCount')
+
+  attrs = newAttrs(*('timestamp', 'text', 'title', 'username'))
 
   fOut.write('FIELDS_HEADER_INDICATOR###	%s\n' % ('\t'.join(ATTS)))
   
@@ -133,7 +134,7 @@ def convert(fIn, fOut):
         if count % 100000 == 0:
           print '%d...' % count
         
-      attrs = {}
+      attrs = newAttrs(*('timestamp', 'text', 'title', 'username'))
       isRedirect = False
 
     if tag in ('timestamp', 'text', 'title', 'username'):
@@ -156,6 +157,9 @@ def convert(fIn, fOut):
 
 def get(attrs, *names):
   return [toUTF8(attrs[x]) for x in names]
+
+def newAttrs(*names):
+  return dict((att, '') for att in names)
 
 if __name__ == '__main__':
   f = open(sys.argv[1], 'rb')


### PR DESCRIPTION
This includes changes I suggested in https://github.com/mikemccand/luceneutil/pull/69.

- Fix on wikiXMLToText.py for handling jawiki dump
- Switch the tested analyzers according to the second argument ("lang") in TestAnalyzerPerf.java

We may also need to change the python scripts?